### PR TITLE
Add failure notifications for Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,56 +1,67 @@
-stage name: 'clean-workspace'
-node('slave') {
-    step([$class: 'WsCleanup'])
-}
-
-// check out code
-stage name: 'check-out-code'
-node('slave') {
-    dir('src') {
-        checkout scm
+try {
+    stage name: 'clean-workspace'
+    node('slave') {
+        step([$class: 'WsCleanup'])
     }
-    stash 'src'
-}
 
-
-// run tests
-stage name: 'test'
-
-node('slave') {
-    unstash 'src'
-    dir('src') {
-        sh 'make test'
-    }
-}
-
-
-// deploy to prod
-if (env.BRANCH_NAME == 'master') {
-    def version = new Date().format("yyyy-MM-dd-'T'HH-mm-ss")
-    withEnv(["DOCKER_TAG=docker-push.ocf.berkeley.edu/rt:${version}"]) {
-        stage name: 'build-prod-image'
-        node('slave') {
-            unstash 'src'
-            dir('src') {
-                sh 'make cook-image'
-            }
+    // check out code
+    stage name: 'check-out-code'
+    node('slave') {
+        dir('src') {
+            checkout scm
         }
+        stash 'src'
+    }
 
-        stage name: 'push-to-registry'
-        node('deploy') {
-            unstash 'src'
-            dir('src') {
-                sh 'make push-image'
-            }
+
+    // run tests
+    stage name: 'test'
+
+    node('slave') {
+        unstash 'src'
+        dir('src') {
+            sh 'make test'
         }
     }
 
-    stage name: 'deploy-to-prod'
-    build job: 'marathon-deploy-app', parameters: [
-        [$class: 'StringParameterValue', name: 'app', value: 'rt'],
-        [$class: 'StringParameterValue', name: 'version', value: version],
-    ]
-}
 
+    // deploy to prod
+    if (env.BRANCH_NAME == 'master') {
+        def version = new Date().format("yyyy-MM-dd-'T'HH-mm-ss")
+        withEnv(["DOCKER_TAG=docker-push.ocf.berkeley.edu/rt:${version}"]) {
+            stage name: 'build-prod-image'
+            node('slave') {
+                unstash 'src'
+                dir('src') {
+                    sh 'make cook-image'
+                }
+            }
+
+            stage name: 'push-to-registry'
+            node('deploy') {
+                unstash 'src'
+                dir('src') {
+                    sh 'make push-image'
+                }
+            }
+        }
+
+        stage name: 'deploy-to-prod'
+        build job: 'marathon-deploy-app', parameters: [
+            [$class: 'StringParameterValue', name: 'app', value: 'rt'],
+            [$class: 'StringParameterValue', name: 'version', value: version],
+        ]
+    }
+} catch (err) {
+    def message = "${env.JOB_NAME} (#${env.BUILD_NUMBER}) failed: ${env.BUILD_URL}"
+
+    slackSend color: '#FF0000', message: message
+
+    mail to: 'root@ocf.berkeley.edu',
+      subject: "${env.JOB_NAME} - Build #${env.BUILD_NUMBER} - Failure!",
+      body: message
+
+    throw err
+}
 
 // vim: ft=groovy


### PR DESCRIPTION
This makes Jenkins send a failure notification to both Slack and email when builds fail. I'm guessing we want this on all branches, not just master, I think that would be best.

The email and Slack message look like this:

![email-failure](https://cloud.githubusercontent.com/assets/1523594/23123380/f1763ee4-f71c-11e6-8213-d7a70d24acc4.png)
![jenkins-failure](https://cloud.githubusercontent.com/assets/1523594/23123309/b5ffbd9a-f71c-11e6-8698-a28d72596e49.png)
