### PR TITLE
Switch to PAM authentication

### DIFF
--- a/99-ocf.pm
+++ b/99-ocf.pm
@@ -7,7 +7,7 @@ Set($CorrespondAddress , 'root@ocf.berkeley.edu');
 Set($CommentAddress , 'root@ocf.berkeley.edu');
 Set($SetOutgoingMailFrom, 1);
 
-# Use external authentication provided by mod_auth_kerb
+# Use external authentication provided by mod_authnz_pam
 Set($WebRemoteUserAuth , 1);
 Set($WebFallbackToRTLogin, 1);
 # create users automatically if no user matching REMOTE_USER is found

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,12 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apache2 \
         cpanminus \
-        libapache2-mod-auth-kerb \
+        libapache2-mod-authnz-pam \
         libapache2-mod-rpaf \
         libapache2-mod-perl2 \
         # The next two are for building RT modules from CPAN
         libmodule-install-perl \
+        libpam-krb5 \
         make \
         patch \
         request-tracker4 \
@@ -22,8 +23,11 @@ RUN cpanm RT::Extension::MergeUsers \
           RT::Extension::CommandByMail \
           RT::Extension::Tags \
           MasonX::Profiler
+
 COPY apache2/ /etc/apache2/
 COPY run healthcheck /opt/rt/
+RUN echo "ocfstaff\nopstaff" > /opt/rt/allowed-groups
+COPY rt_pam /etc/pam.d/rt
 COPY 99-ocf.pm /etc/request-tracker4/RT_SiteConfig.d/
 RUN a2enmod headers rewrite rpaf
 COPY hide-reply-link-for-comments.patch /tmp/

--- a/apache2/sites-enabled/25-rt.ocf.berkeley.edu.conf
+++ b/apache2/sites-enabled/25-rt.ocf.berkeley.edu.conf
@@ -16,17 +16,15 @@
   <Location "/">
     Require valid-user
     SetHandler modperl
-    AuthType Kerberos
+
+    AuthType Basic
+    AuthName 'rt'
+    AuthBasicProvider PAM
+    AuthBasicAuthoritative Off
+    AuthPAMService rt
 
     PerlResponseHandler Plack::Handler::Apache2
     PerlSetVar psgi_app /usr/share/request-tracker4/libexec/rt-server
-
-    KrbMethodNegotiate On
-    KrbMethodK5Passwd On
-    KrbLocalUserMapping On
-    KrbServiceName HTTP/lb.ocf.berkeley.edu
-    # This must be readable by www-data
-    Krb5KeyTab /tmp/rt.keytab
   </Location>
 
   <Location "/REST/1.0">

--- a/rt_pam
+++ b/rt_pam
@@ -1,0 +1,9 @@
+# Restrict access to groups specified in allowed-groups, currently ocfstaff and opstaff
+
+@include common-auth
+@include common-account
+@include common-password
+@include common-session
+
+# Must be in the ocfstaff group to access
+auth required pam_listfile.so onerr=fail item=group sense=allow file=/opt/rt/allowed-groups


### PR DESCRIPTION
This (finally) solves ocf.io/rt/5948. It changes RT to use PAM authentication, and only allows opstaff and ocfstaff to log in.

This has been tested on my staffvm.