### PR TITLE
Move from marathon to prod kubernetes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,5 @@
 servicePipeline(
     upstreamProjects: ['dockers/master'],
-    deployTargets: ['rt'],
 )
 
 // vim: ft=groovy

--- a/kubernetes/rt.yml.erb
+++ b/kubernetes/rt.yml.erb
@@ -39,7 +39,7 @@ spec:
               name: secrets
           env:
             - name: SERVER_NAME
-              value: rt.dev-kubernetes.ocf.berkeley.edu
+              value: rt.ocf.berkeley.edu
       volumes:
         - name: secrets
           hostPath:
@@ -57,7 +57,7 @@ metadata:
   name: virtual-host-ingress
 spec:
   rules:
-    - host: rt.dev-kubernetes.ocf.berkeley.edu
+    - host: rt.ocf.berkeley.edu
       http:
         paths:
           - backend:


### PR DESCRIPTION
I hastily committed the Kubernetes config in a previous commit, so feel free to leave comments on any part of the Kubernetes config, not just the parts that were changed.

Jaws is now a Kubernetes worker, so the cluster should have the capacity to make this happen. However I'll hold off on merging this until `ocf.io` redirects work (https://github.com/ocf/puppet/pull/540), in case people like to use those.