### PR TITLE
Enable healthcheck in kubernetes

### DIFF
--- a/kubernetes/rt.yml.erb
+++ b/kubernetes/rt.yml.erb
@@ -40,6 +40,22 @@ spec:
           env:
             - name: SERVER_NAME
               value: rt.ocf.berkeley.edu
+          livenessProbe:
+            exec:
+              command:
+              - sh
+              - '-c'
+              - '/opt/rt/healthcheck $SERVICE_SERVICE_HOST $SERVICE_SERVICE_PORT'
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - sh
+              - '-c'
+              - '/opt/rt/healthcheck $SERVICE_SERVICE_HOST $SERVICE_SERVICE_PORT'
+            initialDelaySeconds: 5
+            periodSeconds: 5
       volumes:
         - name: secrets
           hostPath:


### PR DESCRIPTION
I recently realized we haven't been using this healthcheck since migrating the service to Kubernetes. This is tested in prod and appears to work.