### PR TITLE
give RT pod 4GiB

### DIFF
--- a/kubernetes/rt.yml.erb
+++ b/kubernetes/rt.yml.erb
@@ -30,7 +30,7 @@ spec:
           image: "docker.ocf.berkeley.edu/rt:<%= version %>"
           resources:
             limits:
-              memory: 2048Mi
+              memory: 4096Mi
               cpu: 750m
           ports:
             - containerPort: 80

--- a/kubernetes/rt.yml.erb
+++ b/kubernetes/rt.yml.erb
@@ -31,7 +31,7 @@ spec:
           resources:
             limits:
               memory: 4096Mi
-              cpu: 750m
+              cpu: 2000m
           ports:
             - containerPort: 80
           volumeMounts:


### PR DESCRIPTION
It turns out that under load, RT can use quite a bit of memory. This will avoid the pod getting killed for it.