### PR TITLE
switch to keycloak OIDC authnz

### DIFF
--- a/99-ocf.pm
+++ b/99-ocf.pm
@@ -7,7 +7,7 @@ Set($CorrespondAddress , 'root@ocf.berkeley.edu');
 Set($CommentAddress , 'root@ocf.berkeley.edu');
 Set($SetOutgoingMailFrom, 1);
 
-# Use external authentication provided by mod_authnz_pam
+# Use external authentication provided by mod-auth-openidc
 Set($WebRemoteUserAuth , 1);
 Set($WebFallbackToRTLogin, 1);
 # create users automatically if no user matching REMOTE_USER is found

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.ocf.berkeley.edu/theocf/debian:stretch
+FROM docker.ocf.berkeley.edu/theocf/debian:buster
 
 COPY request-tracker4.preseed /tmp/request-tracker4.preseed
 RUN debconf-set-selections /tmp/request-tracker4.preseed
@@ -6,12 +6,11 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apache2 \
         cpanminus \
-        libapache2-mod-authnz-pam \
+        libapache2-mod-auth-openidc \
         libapache2-mod-rpaf \
         libapache2-mod-perl2 \
         # The next two are for building RT modules from CPAN
         libmodule-install-perl \
-        libpam-krb5 \
         make \
         patch \
         request-tracker4 \
@@ -26,10 +25,8 @@ RUN cpanm RT::Extension::MergeUsers \
 
 COPY apache2/ /etc/apache2/
 COPY run healthcheck /opt/rt/
-RUN echo "ocfstaff\nopstaff" > /opt/rt/allowed-groups
-COPY rt_pam /etc/pam.d/rt
 COPY 99-ocf.pm /etc/request-tracker4/RT_SiteConfig.d/
-RUN a2enmod headers rewrite rpaf
+RUN a2enmod headers rewrite rpaf auth_openidc
 COPY hide-reply-link-for-comments.patch /tmp/
 RUN cd /usr/share/request-tracker4 && patch -p2 < /tmp/hide-reply-link-for-comments.patch
 

--- a/apache2/sites-enabled/25-rt.ocf.berkeley.edu.conf
+++ b/apache2/sites-enabled/25-rt.ocf.berkeley.edu.conf
@@ -13,15 +13,21 @@
   LogFormat "%a %l %u %t \"%r\" %>s %b" common
   CustomLog "/var/log/apache2/access.log" common
 
-  <Location "/">
-    Require valid-user
-    SetHandler modperl
+  OIDCProviderMetadataURL https://auth.ocf.berkeley.edu/auth/realms/ocf/.well-known/openid-configuration
+  OIDCRedirectURI https://${SERVER_NAME}/oauth2callback
+  OIDCCryptoPassphrase ${ENCRYPTION_KEY}
+  OIDCClientID rt
+  OIDCClientSecret ${CLIENT_SECRET}
 
-    AuthType Basic
-    AuthName 'OCF Account'
-    AuthBasicProvider PAM
-    AuthBasicAuthoritative Off
-    AuthPAMService rt
+  OIDCRemoteUserClaim preferred_username
+  OIDCScope "openid profile"
+
+  <Location "/">
+    AuthType openid-connect
+    Require claim roles:ocfstaff
+    Require claim roles:opstaff
+
+    SetHandler modperl
 
     PerlResponseHandler Plack::Handler::Apache2
     PerlSetVar psgi_app /usr/share/request-tracker4/libexec/rt-server

--- a/kubernetes/rt.yml.erb
+++ b/kubernetes/rt.yml.erb
@@ -40,6 +40,16 @@ spec:
           env:
             - name: SERVER_NAME
               value: rt.ocf.berkeley.edu
+            - name: CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-secret
+                  key: secret
+            - name: ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-secret
+                  key: encryption_key
       volumes:
         - name: secrets
           hostPath:
@@ -63,3 +73,12 @@ spec:
           - backend:
               serviceName: service
               servicePort: 80
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-secret
+type: Opaque
+stringData:
+  secret: <%= keycloak_secret %>
+  encryption_key: <%= keycloak_encryption_key %>

--- a/rt_pam
+++ b/rt_pam
@@ -1,9 +1,0 @@
-# Restrict access to groups specified in allowed-groups, currently ocfstaff and opstaff
-
-@include common-auth
-@include common-account
-@include common-password
-@include common-session
-
-# Must be in the ocfstaff group to access
-auth required pam_listfile.so onerr=fail item=group sense=allow file=/opt/rt/allowed-groups

--- a/run
+++ b/run
@@ -4,6 +4,4 @@
 #
 # Note also that symlinks do not work in the RT_SiteConfig.d directory.
 cp /opt/share/secrets/rt/rt-db /etc/request-tracker4/RT_SiteConfig.d/98-ocfdb.pm
-cp /opt/share/secrets/rt/rt.keytab /tmp/rt.keytab
-chown www-data:root /tmp/rt.keytab
 exec apachectl -d /etc/apache2 -f apache2.conf -e info -DFOREGROUND


### PR DESCRIPTION
This commit also upgrades the image to Buster, since we need a later version of libapache2-mod-auth-openidc to check for the ocfstaff role.