### PR TITLE
Sort RT tickets by DESC order?

### DIFF
--- a/99-ocf.pm
+++ b/99-ocf.pm
@@ -56,3 +56,5 @@ Set($AutocompleteOwners, 1);
 # most time on so we can try to make RT faster to load
 use MasonX::Profiler;
 Set(@MasonParameters, (preamble => 'my $p = MasonX::Profiler->new($m, $r);'));
+
+Set($DefaultSearchResultOrder, 'DESC')


### PR DESCRIPTION
I *think* this sorts tickets in descending order, instead of the current ascending order. So I think this will put the newest tickets first, which seems desirable.

Based on https://docs.bestpractical.com/rt/4.4.1/RT_Config.html#DefaultSearchResultOrder