### PR TITLE
bump ingress-nginx client_max_body_size

### DIFF
--- a/kubernetes/rt.yml.erb
+++ b/kubernetes/rt.yml.erb
@@ -65,6 +65,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: virtual-host-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 16m
 spec:
   rules:
     - host: rt.ocf.berkeley.edu


### PR DESCRIPTION
This allows for larger attachments in emails, which otherwise cause the emails to get dropped after anthrax.