### PR TITLE
Revert "Fill in email address from ocfEmail LDAP attribute"

### DIFF
--- a/99-ocf.pm
+++ b/99-ocf.pm
@@ -19,7 +19,7 @@ Set($ExternalInfoPriority, ['ldap']);
 Set($ExternalSettings, {
 	'ldap' => {
 		'type'             =>  'ldap',
-		'server'           =>  'ldaps://ldap.ocf.berkeley.edu',
+		'server'           =>  'ldap.ocf.berkeley.edu',
 		'tls'              => {
 		    'verify' => 'require',
 		    'cafile' => '/etc/ssl/certs/ca-certificates.crt',

--- a/99-ocf.pm
+++ b/99-ocf.pm
@@ -14,28 +14,6 @@ Set($WebFallbackToRTLogin, 1);
 Set($WebRemoteUserAutocreate, 1);
 Set($WebRemoteUserGecos, undef);
 
-Set($ExternalInfoPriority, ['ldap']);
-# Fetch EmailAddress from the ocfEmail LDAP attribute
-Set($ExternalSettings, {
-	'ldap' => {
-		'type'             =>  'ldap',
-		'server'           =>  'ldap.ocf.berkeley.edu',
-		'tls'              => {
-		    'verify' => 'require',
-		    'cafile' => '/etc/ssl/certs/ca-certificates.crt',
-		},
-		'base'             =>  'ou=People,dc=OCF,dc=Berkeley,dc=EDU',
-		'filter'           =>  '(objectClass=ocfAccount)',
-		'attr_match_list'  => [
-		    'Name',
-		],
-		'attr_map' => {
-		    'Name'         => 'uid',
-		    'EmailAddress' => 'ocfEmail',
-		},
-	},
-} );
-
 # Plugins
 Set(@MailPlugins, qw(Auth::MailFrom Action::CommandByMail));
 Plugin('RT::Extension::CommandByMail');


### PR DESCRIPTION
Reverts ocf/rt#23.

This broke new "user" creation when arbitrary people send us an email. Hopefully we didn't drop too many emails.