### PR TITLE
Add REST2 plugin to RT (untested)

### DIFF
--- a/99-ocf.pm
+++ b/99-ocf.pm
@@ -43,10 +43,8 @@ Set($ExternalSettings, {
 
 # Plugins
 Set(@MailPlugins, qw(Auth::MailFrom Action::CommandByMail));
-Plugin('RT::Authen::Token');
 Plugin('RT::Extension::CommandByMail');
 Plugin('RT::Extension::MergeUsers');
-Plugin('RT::Extension::REST2');
 Plugin('RT::Extension::Tags');
 
 # Make links clicky

--- a/99-ocf.pm
+++ b/99-ocf.pm
@@ -45,6 +45,7 @@ Set($ExternalSettings, {
 Set(@MailPlugins, qw(Auth::MailFrom Action::CommandByMail));
 Plugin('RT::Extension::CommandByMail');
 Plugin('RT::Extension::MergeUsers');
+Plugin('RT::Extension::REST2');
 Plugin('RT::Extension::Tags');
 
 # Make links clicky

--- a/99-ocf.pm
+++ b/99-ocf.pm
@@ -43,6 +43,7 @@ Set($ExternalSettings, {
 
 # Plugins
 Set(@MailPlugins, qw(Auth::MailFrom Action::CommandByMail));
+Plugin('RT::Authen::Token');
 Plugin('RT::Extension::CommandByMail');
 Plugin('RT::Extension::MergeUsers');
 Plugin('RT::Extension::REST2');
@@ -61,6 +62,9 @@ Set( %FullTextSearch,
     Enable     => 1,
     Indexed    => 0
 );
+
+# Disable password prompt when creating authentication tokens
+Set($DisablePasswordForAuthToken, 1);
 
 # Use wrapped plain text instead of HTML email
 Set($MessageBoxRichText, undef);

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,7 @@ RUN ./configure \
 # These must be installed after RT
 RUN cpanm RT::Extension::MergeUsers \
       RT::Extension::CommandByMail \
-      RT::Extension::REST2 \
       RT::Extension::Tags \
-      RT::Authen::Token \
       Net::LDAP
 
 COPY msmtprc /etc/msmtprc

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN cpanm RT::Extension::MergeUsers \
       RT::Extension::CommandByMail \
       RT::Extension::REST2 \
       RT::Extension::Tags \
+      RT::Authen::Token \
       Net::LDAP
 
 COPY msmtprc /etc/msmtprc

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN ./configure \
 # These must be installed after RT
 RUN cpanm RT::Extension::MergeUsers \
       RT::Extension::CommandByMail \
+      RT::Extension::REST2 \
       RT::Extension::Tags \
       Net::LDAP
 

--- a/apache2/sites-enabled/25-rt.ocf.berkeley.edu.conf
+++ b/apache2/sites-enabled/25-rt.ocf.berkeley.edu.conf
@@ -26,6 +26,7 @@
     AuthType openid-connect
     Require claim roles:ocfstaff
     Require claim roles:opstaff
+    SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 
     SetHandler modperl
 


### PR DESCRIPTION
Documentation for the new REST API plugin is here: https://metacpan.org/pod/RT::Extension::REST2

This allows us to use access tokens for authentication with JSON. This PR is currently untested.

To-dos to check:
- [ ] Check that RT doesn't break
- [ ] Ensure REST2 API works with access tokens
- [ ] Can the lines for the access token plugin be removed? (access tokens seem to already be supported on our instance of RT without an explicit statement)

We should also consider running a test instance of RT in the future to prevent having to test changes on production (tm).